### PR TITLE
feat: Define TasteCuration domain model (TasteScore, TasteVerdict)

### DIFF
--- a/src/domain/models/TasteScore.ts
+++ b/src/domain/models/TasteScore.ts
@@ -1,0 +1,29 @@
+/** Per-dimension taste score. Each field is a float in [0, 1]. */
+export interface TasteScore {
+  /** How clearly the idea or content is communicated. */
+  clarity: number;
+  /** Information density — how much substance per unit of text. */
+  density: number;
+  /** Degree to which the content avoids generic, clichéd thinking. */
+  nonGeneric: number;
+  /** Depth of insight or novel perspective offered. */
+  insight: number;
+}
+
+/** Ordered list of all score dimensions for iteration. */
+export const TASTE_SCORE_DIMENSIONS: (keyof TasteScore)[] = [
+  "clarity",
+  "density",
+  "nonGeneric",
+  "insight",
+];
+
+/** Returns true if the value is a TasteScore with all dimensions in [0, 1]. */
+export function isValidTasteScore(value: TasteScore): boolean {
+  if (!value || typeof value !== "object") return false;
+  for (const dim of TASTE_SCORE_DIMENSIONS) {
+    const v = value[dim];
+    if (typeof v !== "number" || isNaN(v) || v < 0 || v > 1) return false;
+  }
+  return true;
+}

--- a/src/domain/models/TasteVerdict.ts
+++ b/src/domain/models/TasteVerdict.ts
@@ -1,0 +1,26 @@
+import { TasteScore, isValidTasteScore } from "./TasteScore";
+
+/** Categorical quality verdict for a piece of content. */
+export type VerdictCategory = "high" | "medium" | "low" | "reject";
+
+/** Ordered list of all valid verdict categories. */
+export const VERDICT_CATEGORIES: VerdictCategory[] = ["high", "medium", "low", "reject"];
+
+/** Full taste verdict combining a categorical label, per-dimension scores, and an explanation. */
+export interface TasteVerdict {
+  /** Overall categorical quality label. */
+  verdict: VerdictCategory;
+  /** Per-dimension numeric sub-scores (each in [0, 1]). */
+  scores: TasteScore;
+  /** Human-readable explanation of the verdict. Must be non-empty. */
+  explanation: string;
+}
+
+/** Returns true if the value is a valid TasteVerdict with consistent fields. */
+export function isValidTasteVerdict(value: TasteVerdict): boolean {
+  if (!value || typeof value !== "object") return false;
+  if (!(VERDICT_CATEGORIES as string[]).includes(value.verdict)) return false;
+  if (!value.scores || !isValidTasteScore(value.scores)) return false;
+  if (typeof value.explanation !== "string" || value.explanation.length === 0) return false;
+  return true;
+}

--- a/tests/domain/TasteScore.test.ts
+++ b/tests/domain/TasteScore.test.ts
@@ -1,0 +1,57 @@
+import {
+  TasteScore,
+  isValidTasteScore,
+  TASTE_SCORE_DIMENSIONS,
+} from "../../src/domain/models/TasteScore";
+
+describe("TasteScore", () => {
+  const validScore: TasteScore = {
+    clarity: 0.8,
+    density: 0.6,
+    nonGeneric: 0.9,
+    insight: 0.7,
+  };
+
+  describe("TASTE_SCORE_DIMENSIONS", () => {
+    it("should list all four dimensions", () => {
+      expect(TASTE_SCORE_DIMENSIONS).toEqual(["clarity", "density", "nonGeneric", "insight"]);
+    });
+  });
+
+  describe("isValidTasteScore", () => {
+    it("should return true for a valid score with all fields in [0,1]", () => {
+      expect(isValidTasteScore(validScore)).toBe(true);
+    });
+
+    it("should return true for boundary values 0 and 1", () => {
+      const boundary: TasteScore = { clarity: 0, density: 1, nonGeneric: 0, insight: 1 };
+      expect(isValidTasteScore(boundary)).toBe(true);
+    });
+
+    it("should return false if any field exceeds 1", () => {
+      expect(isValidTasteScore({ ...validScore, clarity: 1.1 })).toBe(false);
+    });
+
+    it("should return false if any field is below 0", () => {
+      expect(isValidTasteScore({ ...validScore, density: -0.1 })).toBe(false);
+    });
+
+    it("should return false if a field is NaN", () => {
+      expect(isValidTasteScore({ ...validScore, insight: NaN })).toBe(false);
+    });
+
+    it("should return false if a required field is missing", () => {
+      const { nonGeneric: _, ...partial } = validScore;
+      expect(isValidTasteScore(partial as TasteScore)).toBe(false);
+    });
+
+    it("should return false for non-object input", () => {
+      expect(isValidTasteScore(null as unknown as TasteScore)).toBe(false);
+      expect(isValidTasteScore("string" as unknown as TasteScore)).toBe(false);
+    });
+
+    it("should return false for non-numeric field values", () => {
+      expect(isValidTasteScore({ ...validScore, clarity: "high" as unknown as number })).toBe(false);
+    });
+  });
+});

--- a/tests/domain/TasteVerdict.test.ts
+++ b/tests/domain/TasteVerdict.test.ts
@@ -1,0 +1,77 @@
+import {
+  TasteVerdict,
+  VerdictCategory,
+  VERDICT_CATEGORIES,
+  isValidTasteVerdict,
+} from "../../src/domain/models/TasteVerdict";
+
+describe("TasteVerdict", () => {
+  const validScores = {
+    clarity: 0.8,
+    density: 0.6,
+    nonGeneric: 0.9,
+    insight: 0.7,
+  };
+
+  const validVerdict: TasteVerdict = {
+    verdict: "high",
+    scores: validScores,
+    explanation: "This piece demonstrates exceptional clarity and non-generic insight.",
+  };
+
+  describe("VERDICT_CATEGORIES", () => {
+    it("should contain all four categories", () => {
+      expect(VERDICT_CATEGORIES).toEqual(["high", "medium", "low", "reject"]);
+    });
+  });
+
+  describe("isValidTasteVerdict", () => {
+    it("should return true for a valid verdict with all fields", () => {
+      expect(isValidTasteVerdict(validVerdict)).toBe(true);
+    });
+
+    it("should accept all valid verdict categories", () => {
+      const categories: VerdictCategory[] = ["high", "medium", "low", "reject"];
+      for (const verdict of categories) {
+        expect(isValidTasteVerdict({ ...validVerdict, verdict })).toBe(true);
+      }
+    });
+
+    it("should return false for an invalid verdict category", () => {
+      expect(
+        isValidTasteVerdict({ ...validVerdict, verdict: "excellent" as VerdictCategory })
+      ).toBe(false);
+    });
+
+    it("should return false if explanation is empty string", () => {
+      expect(isValidTasteVerdict({ ...validVerdict, explanation: "" })).toBe(false);
+    });
+
+    it("should return false if explanation is not a string", () => {
+      expect(
+        isValidTasteVerdict({ ...validVerdict, explanation: 42 as unknown as string })
+      ).toBe(false);
+    });
+
+    it("should return false if scores contain out-of-range values", () => {
+      expect(
+        isValidTasteVerdict({ ...validVerdict, scores: { ...validScores, clarity: 1.5 } })
+      ).toBe(false);
+    });
+
+    it("should return false if scores field is missing", () => {
+      const { scores: _, ...partial } = validVerdict;
+      expect(isValidTasteVerdict(partial as TasteVerdict)).toBe(false);
+    });
+
+    it("should return false if verdict field is missing", () => {
+      const { verdict: _, ...partial } = validVerdict;
+      expect(isValidTasteVerdict(partial as TasteVerdict)).toBe(false);
+    });
+
+    it("should return false for null or non-object input", () => {
+      expect(isValidTasteVerdict(null as unknown as TasteVerdict)).toBe(false);
+      expect(isValidTasteVerdict(undefined as unknown as TasteVerdict)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Define TasteCuration domain model (TasteScore, TasteVerdict)

## Issue
Closes #2

## Implementation
Done. Here's a summary of what was implemented:

**Branch:** `feat/architecture-2`

**Files created:**
- `src/domain/models/TasteScore.ts` — `TasteScore` interface (4 float fields: `clarity`, `density`, `nonGeneric`, `insight`) + `isValidTasteScore` validator + `TASTE_SCORE_DIMENSIONS` constant
- `src/domain/models/TasteVerdict.ts` — `VerdictCategory` union type, `TasteVerdict` interface (verdict + scores + explanation) + `isValidTasteVerdict` validator + `VERDICT_CATEGORIES` constant
- `tests/d

## Cost
Claude session cost: $0.5509 (22 turns)